### PR TITLE
preventing tact error E_REPAIR (28)

### DIFF
--- a/hook_lib/Main.cpp
+++ b/hook_lib/Main.cpp
@@ -55,6 +55,9 @@ BOOL WINAPI DllMain(HMODULE hModule, DWORD Reason, LPVOID lpVoid)
 
 		printf("Base Address: %p\n", 0_b);
 
+		// prevents tact error E_REPAIR (28) from happening
+		remove("Data/data/CASCRepair.mrk");
+
 		debug_output_init(nullptr);
 		addCustomCmds();
 		patchGame();


### PR DESCRIPTION
prevents error "Failed to initialize TACT client : E_REPAIR (28), invalid build info?" from happening